### PR TITLE
IMitmServiceObject: add default implementation for ShouldMitm

### DIFF
--- a/include/stratosphere/mitm/imitmserviceobject.hpp
+++ b/include/stratosphere/mitm/imitmserviceobject.hpp
@@ -39,7 +39,9 @@ class IMitmServiceObject : public IServiceObject {
             return this->process_id;
         }
         
-        static bool ShouldMitm(u64 pid, u64 tid);
+        static bool ShouldMitm(u64 pid, u64 tid) {
+            return true;
+        }
                 
     protected:
         virtual ~IMitmServiceObject() = default;


### PR DESCRIPTION
This function is declared, but not defined. Not an issue if you declare it in your subclass, but it's nice to have a default. I think that mitm'ing everything is a reasonable default.