### PR TITLE
Silence -Wmissing-field-initializer warnings

### DIFF
--- a/include/stratosphere/hossynch.hpp
+++ b/include/stratosphere/hossynch.hpp
@@ -256,7 +256,7 @@ class HosSignal {
 
 class HosThread {
     private:
-        Thread thr = {0};
+        Thread thr = {};
     public:
         HosThread() {}
         

--- a/include/stratosphere/ipc/ipc_serialization.hpp
+++ b/include/stratosphere/ipc/ipc_serialization.hpp
@@ -511,7 +511,7 @@ struct Encoder<MetaInfo, std::tuple<Args...>> {
         if (IsDomainObject(ctx->obj_holder)) {
             raw = (decltype(raw))ipcPrepareHeaderForDomain(&ctx->reply, sizeof(*raw), 0);
             auto resp_header = (DomainResponseHeader *)((uintptr_t)raw - sizeof(DomainResponseHeader));
-            *resp_header = {0};
+            *resp_header = {};
         } else {
             raw = (decltype(raw))ipcPrepareHeader(&ctx->reply, sizeof(*raw));
         }
@@ -541,7 +541,7 @@ struct Encoder<MetaInfo, std::tuple<Args...>> {
         if (is_domain) {
             raw = (decltype(raw))ipcPrepareHeaderForDomain(&ctx->reply, sizeof(*raw) + MetaInfo::OutRawArgSize + sizeof(*ctx->out_object_ids) * MetaInfo::NumOutSessions, 0);
             auto resp_header = (DomainResponseHeader *)((uintptr_t)raw - sizeof(DomainResponseHeader));
-            *resp_header = {0};
+            *resp_header = {};
             resp_header->NumObjectIds = MetaInfo::NumOutSessions;
         } else {
             raw = (decltype(raw))ipcPrepareHeader(&ctx->reply, sizeof(*raw)+ MetaInfo::OutRawArgSize);

--- a/include/stratosphere/ipc/ipc_service_session.hpp
+++ b/include/stratosphere/ipc/ipc_service_session.hpp
@@ -109,7 +109,7 @@ class ServiceSession : public IWaitable
                 u64 result;
             } *raw = (decltype(raw))ipcPrepareHeader(&ctx->reply, sizeof(*raw));
             
-            raw->hdr = (DomainResponseHeader){0};
+            raw->hdr = {};
             raw->magic = SFCO_MAGIC;
             raw->result = rc;
             return raw->result;


### PR DESCRIPTION
This greatly lessens the amount of warning spam about missing field initializers in atmosphere, given how prevalent the includes from this project are. With this, most of the remaining warnings about this category (when compiling the loader) are from libnx.