### PR TITLE
firmware_version: Add missing break in SetFirmwareVersionForLibnx()

### DIFF
--- a/source/firmware_version.cpp
+++ b/source/firmware_version.cpp
@@ -124,6 +124,7 @@ void SetFirmwareVersionForLibnx() {
             major = 7;
             minor = 0;
             micro = 0;
+            break;
         case FirmwareVersion_800:
             major = 8;
             minor = 0;


### PR DESCRIPTION
A break was left out when updating the switch to add firmware version 8.0.0